### PR TITLE
website-old git repo

### DIFF
--- a/website.yml
+++ b/website.yml
@@ -4,7 +4,7 @@
   vars:
     www: true
     domain: "{{ website_domain }}"
-    repo: https://github.com/pyslackers/website.git
+    repo: https://github.com/pyslackers/website-old.git
     service_name: pyslackers-website
     site_port: "{{ website_port }}"
     username: "{{ website_user }}"


### PR DESCRIPTION
use the old website repo to avoid breaking the ansible due to
repositorie rename