### PR TITLE
Closes #37: Refactors domains in nginx

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 ssl: false
-www: false
 static_dir: false

--- a/roles/nginx/handlers/main.yml
+++ b/roles/nginx/handlers/main.yml
@@ -12,3 +12,9 @@
   service:
     name: nginx
     state: started
+
+- name: reload nginx
+  service:
+    name: nginx.service
+    state: reloaded
+  when: "enabled_sites.changed"

--- a/roles/nginx/tasks/http.yml
+++ b/roles/nginx/tasks/http.yml
@@ -1,19 +1,15 @@
 ---
-- name: make the domain {{ domain }} available
+- name: "make {{ domains | join(',') }} available"
   template:
     src: etc/nginx/sites-available/site-available.j2
-    dest: "/etc/nginx/sites-available/{{ domain }}"
-  register: available_sites
+    dest: "/etc/nginx/sites-available/{{ domains | first }}"
 
-- name: enable the domain {{ domain }}
+- name: "enable {{ domains | join(',') }}"
   file:
-    src: "/etc/nginx/sites-available/{{ domain }}"
-    dest: "/etc/nginx/sites-enabled/{{ domain }}"
+    src: "/etc/nginx/sites-available/{{ domains | first }}"
+    dest: "/etc/nginx/sites-enabled/{{ domains | first }}"
     state: link
   register: enabled_sites
+  notify:
+    - reload nginx
 
-- name: reload nginx
-  service:
-    name: nginx.service
-    state: reloaded
-  when: "enabled_sites.changed or available_sites.changed"

--- a/roles/nginx/tasks/ssl.yml
+++ b/roles/nginx/tasks/ssl.yml
@@ -10,9 +10,9 @@
     name: certbot
     state: latest
 
-- name: "check if ssl certs for {{ domain }} are already generated"
+- name: "check if ssl certs for {{ domains | join(',') }} are already generated"
   stat:
-    path: "/etc/letsencrypt/live/{{ domain }}/fullchain.pem"
+    path: "/etc/letsencrypt/live/{{ domains | first }}/fullchain.pem"
   register: fullchain
 
 - name: stop nginx
@@ -21,9 +21,9 @@
     state: stopped
   when: not fullchain.stat.exists
 
-- name: "generate ssl certificates for {{ domain }}"
+- name: "generate ssl certificates for {{ domains | join(',') }}"
   command: "certbot certonly --standalone --email {{ email }}
-       --agree-tos -n -d {{ domain }}{% if www %},www.{{ domain }} {% endif %}{% if ssl_staging %} --staging {% endif %}"
+       --agree-tos -n -d {{ domains | join(',') }}{% if ssl_staging %} --staging{% endif %}"
   when: not fullchain.stat.exists
 
 - name: create a cron job to autorenew all ssl certificates
@@ -32,4 +32,4 @@
     minute: 1
     hour: 23
     weekday: 0
-    job: '/usr/bin/certbot renew --quiet --renew-hook "/usr/sbin/service nginx reload"'
+    job: '/usr/bin/certbot renew --quiet --pre-hook "systemctl stop nginx.service" --post-hook "systemctl start nginx.service"'

--- a/roles/nginx/templates/etc/nginx/sites-available/site-available.j2
+++ b/roles/nginx/templates/etc/nginx/sites-available/site-available.j2
@@ -9,9 +9,9 @@ server {
     listen 80;
     listen [::]:80;
 
-    server_name {{ domain }} {% if www %}www.{{ domain }}{% endif %};
+    server_name {{ domains | join(' ') }};
 
-    root /var/www/{{ domain }};
+    root /var/www/{{ domains | first }};
     index index.html;
 
 
@@ -46,18 +46,18 @@ server {
 
 {% if ssl %}
 server {
-    access_log /var/log/nginx/{{domain}}_access.log;
-    error_log /var/log/nginx/{{domain}}_error.log;
+    access_log /var/log/nginx/{{ domains | first }}_access.log;
+    error_log /var/log/nginx/{{ domains | first }}_error.log;
     charset utf-8;
 
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
-    server_name {{ domain }} {% if www %}www.{{ domain }}{% endif %};
+    server_name {{ domains | join(' ') }};
 
     # ssl_dhparam /etc/ssl/certs/dhparam.pem;
-    ssl_certificate /etc/letsencrypt/live/{{ domain }}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/{{ domain }}/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/{{ domains | first }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ domains | first }}/privkey.pem;
 
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_prefer_server_ciphers on;

--- a/sirbot.yml
+++ b/sirbot.yml
@@ -3,12 +3,12 @@
   hosts: sirbot
   vars:
     username: "{{ sirbot_user }}"
-    domain: "{{ sirbot_domain }}"
+    domains:
+      - "{{ sirbot_domain }}"
     service_name: sirbot
     site_port: "{{ sirbot_port }}"
     exec_start: "/home/{{ username }}/.pyvenv/bin/sirbot -c {{ sirbot_config }}"
     work_dir: "/home/{{ username }}/"
-    www: false
     service_environment:
       - "SIRBOT_SLACK_BOT_TOKEN={{ SIRBOT_SLACK_BOT_TOKEN }}"
       - "SIRBOT_SLACK_TOKEN={{ SIRBOT_SLACK_TOKEN }}"

--- a/website.yml
+++ b/website.yml
@@ -2,8 +2,9 @@
 - name: deploy pyslackers website
   hosts: website
   vars:
-    www: true
-    domain: "{{ website_domain }}"
+    domains:
+      - "{{ website_domain }}"
+      - "www.{{ website_domain }}"
     repo: https://github.com/pyslackers/website-old.git
     service_name: pyslackers-website
     site_port: "{{ website_port }}"


### PR DESCRIPTION
Previously we were setting a boolean for `www` (which is a bit funky). Given that `www` is an edge case and is really just a subdomain, this removes that functionality and instead requires the user to explicitly pass in all the domains this nginx instance should handle.

tl;dr: `domain` -> `domains` and should be passed in as a list.

Something to note here, however. The ordering of domain names becomes potentially significant, as some cases only use the first element in the sequence for naming. It really doesn't matter a ton, but if someone prepends another domain - it could leave around a bad cronjob or something.

Closes #37 